### PR TITLE
Add likes, dislikes, comment icons to single proposal card page

### DIFF
--- a/frontend/src/app/[locale]/(default)/proposed-governance-actions/[id]/page.js
+++ b/frontend/src/app/[locale]/(default)/proposed-governance-actions/[id]/page.js
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+	Badge,
 	Box,
 	Button,
 	Card,
@@ -16,10 +17,13 @@ import { formatIsoDate } from "@/lib/utils";
 import { Link } from "@/navigation";
 import { useTheme } from "@emotion/react";
 import {
+	IconChatAlt,
 	IconCheveronLeft,
 	IconDotsVertical,
 	IconLink,
 	IconSort,
+	IconThumbDown,
+	IconThumbUp,
 } from "@intersect.mbo/intersectmbo.org-icons-set";
 import { useEffect, useState } from "react";
 const ProposalPage = ({ params: { id } }) => {
@@ -220,6 +224,77 @@ const ProposalPage = ({ params: { id } }) => {
 										</Button>
 									)
 								)}
+							</Box>
+						</Box>
+						<Box
+							mt={4}
+							display={"flex"}
+							flexDirection={"row"}
+							justifyContent={"space-between"}
+						>
+							<IconButton>
+								<Badge
+									badgeContent={32}
+									color={"primary"}
+									aria-label="comments"
+									showZero
+									sx={{
+										transform: "translate(30px, -20px)",
+										"& .MuiBadge-badge": {
+											color: "white",
+											backgroundColor: (theme) =>
+												theme.palette.badgeColors
+													.primary,
+										},
+									}}
+								></Badge>
+								<IconChatAlt />
+							</IconButton>
+							<Box display={"flex"} gap={1}>
+								<IconButton
+									sx={{
+										border: (theme) =>
+											`1px solid ${theme.palette.iconButton.outlineLightColor}`,
+									}}
+								>
+									<Badge
+										badgeContent={1}
+										color={"primary"}
+										aria-label="comments"
+										sx={{
+											transform: "translate(30px, -20px)",
+											"& .MuiBadge-badge": {
+												color: "white",
+												backgroundColor: (theme) =>
+													theme.palette.badgeColors
+														.secondary,
+											},
+										}}
+									></Badge>
+									<IconThumbUp />
+								</IconButton>
+								<IconButton
+									sx={{
+										border: (theme) =>
+											`1px solid ${theme.palette.iconButton.outlineLightColor}`,
+									}}
+								>
+									<Badge
+										badgeContent={0}
+										showZero
+										aria-label="comments"
+										sx={{
+											transform: "translate(30px, -20px)",
+											"& .MuiBadge-badge": {
+												color: "white",
+												backgroundColor: (theme) =>
+													theme.palette.badgeColors
+														.errorLight,
+											},
+										}}
+									></Badge>
+									<IconThumbDown />
+								</IconButton>
 							</Box>
 						</Box>
 					</CardContent>

--- a/frontend/src/components/ProposalCard/index.js
+++ b/frontend/src/components/ProposalCard/index.js
@@ -136,8 +136,14 @@ const ProposalCard = ({ proposal }) => {
 									badgeContent={32}
 									color={"error"}
 									aria-label="comments"
+									showZero
 									sx={{
 										transform: "translate(30px, -20px)",
+										"& .MuiBadge-badge": {
+											color: "white",
+											backgroundColor: (theme) =>
+												theme.palette.badgeColors.error,
+										},
 									}}
 								></Badge>
 								<IconChatAlt />

--- a/frontend/src/components/ThemeProviderWrapper/index.js
+++ b/frontend/src/components/ThemeProviderWrapper/index.js
@@ -2,6 +2,7 @@
 
 import {
 	ThemeProvider,
+	alpha,
 	createTheme,
 	responsiveFontSizes,
 } from "@mui/material/styles";
@@ -13,6 +14,15 @@ let theme = createTheme({
 				black: "#212A3D",
 				error: "#CC0000",
 			},
+		},
+		badgeColors: {
+			primary: "0034AE",
+			error: "CC0000",
+			errorLight: "#FF9999",
+			secondary: "#39B6D5",
+		},
+		iconButton: {
+			outlineLightColor: alpha("#BFC8D9", 0.38),
 		},
 		text: {
 			grey: "#506288",


### PR DESCRIPTION
## List of changes

- Add likes, dislikes and comments icon and badges to single proposal page

## Checklist

- [related issue](https://github.com/IntersectMBO/xxxx/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/xxxx/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
