### PR TITLE
Added Modal for Cancel btn on Step1. 3 options, first close modal and…

### DIFF
--- a/frontend/src/app/[locale]/(create)/proposal-creation/page.js
+++ b/frontend/src/app/[locale]/(create)/proposal-creation/page.js
@@ -5,7 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { IconCheveronLeft } from '@intersect.mbo/intersectmbo.org-icons-set';
 import { useTheme } from '@emotion/react';
 import { Step1, Step2, Step3 } from '@/components/ProposalCreationSteps';
-import { createProposal, createProposalAndProposalContent, updateProposalContent } from "@/lib/api";
+import { createProposalAndProposalContent, updateProposalContent } from "@/lib/api";
 import { useMediaQuery } from '@mui/material';
 
 const ProposalCreation = () => {
@@ -14,8 +14,27 @@ const ProposalCreation = () => {
 	const [proposalData, setProposalData] = useState({});
     const [links, setLinks] = useState([]);
 	const [governanceActionTypes, setGovernanceActionTypes] = useState([]);
+	const [isContinueDisabled, setIsContinueDisabled] = useState(true);
+
 	const isSmallScreen = useMediaQuery(theme => theme.breakpoints.down('sm'));
 
+	const handleIsContinueDisabled = () => {
+        if(proposalData?.gov_action_type_id 
+            && proposalData?.prop_name 
+            && proposalData?.prop_abstract 
+            && proposalData?.prop_motivation 
+            && proposalData?.prop_rationale 
+            && proposalData?.prop_receiving_address 
+            && proposalData?.prop_amount) {  
+            setIsContinueDisabled(false);
+        } else {    
+            setIsContinueDisabled(true);
+        }
+    }
+
+    useEffect(() => {
+		handleIsContinueDisabled();
+	}, [proposalData]);
 
 	const handleSaveDraft = async () => {
 		try {	
@@ -88,6 +107,9 @@ const ProposalCreation = () => {
 					{step === 1 && (
 						<Step1
 							setStep={setStep}
+							isContinueDisabled={isContinueDisabled}
+							setProposalData={setProposalData}
+							handleSaveDraft={handleSaveDraft}
 						/>
 					)}
 
@@ -102,6 +124,7 @@ const ProposalCreation = () => {
 							governanceActionTypes={governanceActionTypes}
 							setGovernanceActionTypes={setGovernanceActionTypes}
 							isSmallScreen={isSmallScreen}
+							isContinueDisabled={isContinueDisabled}
 						/>
 					)}
 

--- a/frontend/src/components/ProposalCreationSteps/LinkManager.js
+++ b/frontend/src/components/ProposalCreationSteps/LinkManager.js
@@ -30,7 +30,7 @@ const LinkManager = ({ maxLinks = 7, links, setLinks }) => {
     return (
         <Box >
             {links.map((link, index) => (
-                <Box key={index} sx={{ marginBottom: 2 }}> 
+                <Box key={index} sx={{ marginBottom: 2, position: 'relative' }}> 
                     <TextField
                         
                         label={`Link #${index + 1} URL`}

--- a/frontend/src/components/ProposalCreationSteps/Step1.js
+++ b/frontend/src/components/ProposalCreationSteps/Step1.js
@@ -4,13 +4,53 @@ import {
     CardContent,
     Typography,
     Button,
+    Modal
 } from '@mui/material';
+import { useState } from 'react';
+import {IconX } from '@intersect.mbo/intersectmbo.org-icons-set';
 import { useRouter } from '@/navigation';
 
+const style = {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: {
+        xs: '90%',
+        sm: '50%',
+        md: '30%',
+    },
+    bgcolor: 'background.paper',
+    boxShadow: 24,
+    borderRadius: '20px',
+};
+
 const Step1 = ({
-    setStep
+    setStep,
+    isContinueDisabled,
+    setProposalData,
+    handleSaveDraft,
 }) => {
     const router = useRouter();
+    const [open, setOpen] = useState(false);
+
+    const handleOpen = () => {
+		setOpen(true);
+    };
+
+    const handleClose= () => {
+		setOpen(false);
+    };
+
+    const handleCancelAndSaveDraft = () => {
+        handleSaveDraft();
+        router.push('/');
+    };
+
+	const handleCancel = () => {
+		setProposalData({});
+        router.push('/');
+    };
 
     return (
         <Card 
@@ -68,7 +108,7 @@ const Step1 = ({
                     <Button
                         variant="outlined"
                         sx={{borderRadius: '20px'}}
-                        onClick={() => router.push('/')}
+                        onClick={handleOpen}
                     >
                         Cancel
                     </Button>
@@ -80,6 +120,76 @@ const Step1 = ({
                         Continue
                     </Button>
                 </Box>
+                <Modal
+                    open={open}
+                    onClose={handleClose}
+                >
+                    <Box sx={style}>
+                        <Box 
+                            pt={2}  
+                            pl={2}
+                            pr={2}
+                            pb={1}
+                            borderBottom={1} 
+                            borderColor={(theme) => theme.palette.border.lightGray}
+                        >
+                            <Box
+                                display="flex"
+                                flexDirection="row"
+                                justifyContent="space-between"
+                            >
+                                <Typography id="modal-modal-title" variant="h6" component="h2">
+                                    Dialog Title
+                                </Typography>
+                                <Button onClick={handleClose} >
+                                    <IconX width='24px' height='24px' />
+                                </Button>
+                            </Box>
+                            <Typography id="modal-modal-description" mt={2} color={(theme) => theme.palette.text.blueGrey} >
+                                A dialog is a type of modal window that appears in front of app content to provide critical information, or prompt for a decision to be made.
+                            </Typography>
+                        </Box>
+
+                        <Box 
+                            display="flex"
+                            flexDirection="column"
+                            padding={2}
+                            gap={2}
+                        >
+                            <Button 
+                                variant="contained"   
+                                fullWidth  
+                                sx={{
+                                    borderRadius: '20px'
+                                }}
+                                onClick={handleClose} 
+                            >
+                                I don't want to cancel
+                            </Button>
+                            <Button 
+                                variant="outlined"   
+                                fullWidth  
+                                sx={{
+                                    borderRadius: '20px'
+                                }}
+                                disabled={isContinueDisabled}
+                                onClick={handleCancelAndSaveDraft} 
+                            >
+                                Yes, cancel & save it as draft
+                            </Button>
+                            <Button 
+                                variant="text"   
+                                fullWidth  
+                                sx={{
+                                    borderRadius: '20px'
+                                }}
+                                onClick={handleCancel} 
+                            >
+                                Yes, cancel and don't save it
+                            </Button>
+                        </Box>
+                    </Box>
+                </Modal>
             </CardContent>
         </Card>
     );

--- a/frontend/src/components/ProposalCreationSteps/Step2.js
+++ b/frontend/src/components/ProposalCreationSteps/Step2.js
@@ -1,6 +1,6 @@
 import { Box, Card, CardContent, Typography, Button, TextField, MenuItem } from '@mui/material';
 import { getGovernanceActionTypes } from "@/lib/api";
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { LinkManager } from '@/components/ProposalCreationSteps';
 
 const Step2 = ({
@@ -12,10 +12,10 @@ const Step2 = ({
     setLinks,
     governanceActionTypes,
     setGovernanceActionTypes,
-    isSmallScreen
+    isSmallScreen,
+    isContinueDisabled
 }) => {
     const maxLength = 256;
-    const [isContinueDisabled, setIsContinueDisabled] = useState(true);
 
     const fetchGovernanceActionTypes = async () => {
 		try {
@@ -32,27 +32,9 @@ const Step2 = ({
 		}
 	};
 
-    const handleIsContinueDisabled = () => {
-        if(proposalData?.gov_action_type_id 
-            && proposalData?.prop_name 
-            && proposalData?.prop_abstract 
-            && proposalData?.prop_motivation 
-            && proposalData?.prop_rationale 
-            && proposalData?.prop_receiving_address 
-            && proposalData?.prop_amount) {  
-            setIsContinueDisabled(false);
-        } else {    
-            setIsContinueDisabled(true);
-        }
-    }
-
 	useEffect(() => {
 		fetchGovernanceActionTypes();
 	}, []);
-
-    useEffect(() => {
-		handleIsContinueDisabled();
-	}, [proposalData]);
 
     return (
         <Card 

--- a/frontend/src/components/ThemeProviderWrapper/index.js
+++ b/frontend/src/components/ThemeProviderWrapper/index.js
@@ -34,6 +34,7 @@ let theme = createTheme({
 		},
 		border: {
 			gray: "#E5DFE3",
+			lightGray: "#CAC4D0",
 		},
 	},
 	components: {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -49,7 +49,8 @@ export const createProposalAndProposalContent = async (proposalContent, links) =
                 prop_poll_active: false,
                 prop_submitted: false,
                 prop_status_id: '1', // TODO: proposal status
-                prop_comments_number: 0
+                prop_comments_number: 0,
+				user_id: proposalContent?.user_id, // TODO: set user_id
             }
         });
 


### PR DESCRIPTION

## List of changes

- Added Modal for Cancel btn on Step1. 3 options, first close modal and return to filling proposal, second close and save as draft, and third just cancel and dont save it. 
- Moved isContinueDisabled, handleIsContinueDisabled to proposal-creation page need in Step 1 and 2. 
- Added color for border in modal.
-  Fix not showing X for removing link in Step 2. 
- Added dummy user_id in api call to create proposal.

## Checklist

- [related issue](https://github.com/IntersectMBO/xxxx/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/xxxx/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
